### PR TITLE
Fixed missing </div> in Terminliste UI

### DIFF
--- a/src/main/resources/templates/termine.html
+++ b/src/main/resources/templates/termine.html
@@ -105,7 +105,7 @@
 						
 						<div style="font-size: xx-large; text-align: center">…</div>
 					<!-- </div> -->
-				<div>
+				</div>
 			
 			</div>
 		</div>


### PR DESCRIPTION
* termine.html, line 108: There was a rogue `<div>` where a `</div>` should
  have been.