### PR TITLE
Implemented Gruppenfilter for Umfrageliste UI

### DIFF
--- a/src/main/java/mops/termine2/controller/UmfragenUebersichtController.java
+++ b/src/main/java/mops/termine2/controller/UmfragenUebersichtController.java
@@ -1,19 +1,6 @@
 package mops.termine2.controller;
 
 
-import java.security.Principal;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.annotation.security.RolesAllowed;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.context.annotation.SessionScope;
-
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import mops.termine2.Konstanten;
@@ -24,6 +11,20 @@ import mops.termine2.models.Umfrageuebersicht;
 import mops.termine2.services.AuthenticationService;
 import mops.termine2.services.GruppeService;
 import mops.termine2.services.UmfragenuebersichtService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.context.annotation.SessionScope;
+
+import javax.annotation.security.RolesAllowed;
+import javax.servlet.http.HttpServletRequest;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
 
 @Controller
 @SessionScope
@@ -47,82 +48,51 @@ public class UmfragenUebersichtController {
 	
 	@GetMapping("/umfragen")
 	@RolesAllowed({Konstanten.ROLE_ORGA, Konstanten.ROLE_STUDENTIN})
-	public String umfragen(Principal p, Model m) {
+	public String umfragen(Principal p, Model m,
+					@RequestParam(name = "gruppe", defaultValue = "Alle Gruppen") String gruppe) {
 		if (p != null) {
 			Account account = authenticationService.createAccountFromPrincipal(p);
 			m.addAttribute(Konstanten.ACCOUNT, account);
+			
 			authenticatedAccess.increment();
-			List<Gruppe> gruppen = gruppeService.loadByBenutzer(account);
+			
 			List<String> gruppenNamen = new ArrayList<>();
+			List<Gruppe> gruppen = gruppeService.loadByBenutzer(account);
 			for (Gruppe g : gruppen) {
 				gruppenNamen.add(g.getName());
 			}
-			List<Umfrage> umfragenOffen = umfragenuebersichtService.loadOffeneUmfragenFuerBenutzer(account);
-			List<Umfrage> umfragenAbgeschlossen =
-					umfragenuebersichtService.loadAbgeschlosseneUmfragenFuerBenutzer(account);
+			
+			List<Umfrage> umfragenOffen;
+			List<Umfrage> umfragenAbgeschlossen;
+			if (gruppe.equals("Alle Gruppen")) {
+				umfragenOffen =
+					umfragenuebersichtService.loadOffeneUmfragenFuerBenutzer(account);
+				umfragenAbgeschlossen = umfragenuebersichtService
+					.loadAbgeschlosseneUmfragenFuerBenutzer(account);
+			} else {
+				umfragenOffen =
+					umfragenuebersichtService.loadOffeneUmfragenFuerGruppe(gruppe);
+				umfragenAbgeschlossen = umfragenuebersichtService
+					.loadAbgeschlosseneUmfragenFuerGruppe(gruppe);
+			}
 			Umfrageuebersicht umfragen =
 					new Umfrageuebersicht(umfragenAbgeschlossen, umfragenOffen, gruppenNamen);
+			
 			m.addAttribute("umfragen", umfragen);
+			m.addAttribute("selektierteGruppe", gruppe);
 		}
-		//_______________________________
-		//_______________________________
-		/* Dummy Daten damit man am thymeleaf arbeiten kann:
-		List<String> gruppen = new ArrayList<String>();
-		gruppen.add("FIXLATER");
-		gruppen.add("WEB24");
-		gruppen.add("GIT-R-DONE");
-		
-		List<Umfrage> umfragenTeilgenommen = new ArrayList<Umfrage>();
-		
-		Umfrage umfrage1 = new Umfrage();
-		umfrage1.setErsteller("studentin");
-		umfrage1.setTitel("Brunch");
-		umfrage1.setBeschreibung("Was sollen wir essen?");
-		umfrage1.setFrist(LocalDateTime.now().plusHours(3));
-		umfrage1.setUmfragenErgebnis("Spaghetti");
-		umfrage1.setGruppe("FIXLATER");
-		
-		umfragenTeilgenommen.add(umfrage1);
-		
-		Umfrage umfrage2 = new Umfrage();
-		umfrage2.setErsteller("studentin");
-		umfrage2.setTitel("Dinner");
-		umfrage2.setBeschreibung("Was sollen wir später essen?");
-		umfrage2.setFrist(LocalDateTime.now().plusHours(6));
-		umfrage2.setUmfragenErgebnis("Kuchen");
-		umfrage2.setGruppe("WEB24");
-		
-		umfragenTeilgenommen.add(umfrage2);
-		
-		List<Umfrage> umfragenOffen = new ArrayList<Umfrage>();
-		
-		Umfrage umfrage3 = new Umfrage();
-		umfrage3.setErsteller("studentin");
-		umfrage3.setTitel("Breakfast");
-		umfrage3.setBeschreibung("Was sollen wir morgen früh essen?");
-		umfrage3.setFrist(LocalDateTime.now().plusHours(23));
-		umfrage3.setUmfragenErgebnis("Eggs and bacon");
-		umfrage3.setGruppe("GIT-R-DONE");
-		
-		umfragenOffen.add(umfrage3);
-		
-		Umfrage umfrage4 = new Umfrage();
-		umfrage4.setErsteller("studentin");
-		umfrage4.setTitel("Lunch");
-		umfrage4.setBeschreibung("Was sollen wir morgen Mittag essen?");
-		umfrage4.setFrist(LocalDateTime.now().plusHours(23));
-		umfrage4.setUmfragenErgebnis("Barbeque");
-		umfrage4.setGruppe("FIXLATER");
-		
-		umfragenOffen.add(umfrage4);
-		
-		Umfrageuebersicht umfragen = new Umfrageuebersicht(umfragenTeilgenommen, umfragenOffen, gruppen);
-		
-		m.addAttribute("umfragen", umfragen);
-		
-		dummy code ends here*/
 		
 		return "umfragen";
+	}
+	
+	@PostMapping(path = "umfragen", params = "details")
+	@RolesAllowed({Konstanten.ROLE_ORGA, Konstanten.ROLE_STUDENTIN})
+	public String details(Principal p, Model m, final HttpServletRequest req) {
+		String link = "";
+		if (p != null) {
+			link = req.getParameter("details");
+		}
+		return "redirect:/termine2/umfragen" + link;
 	}
 }
 

--- a/src/main/java/mops/termine2/services/UmfrageService.java
+++ b/src/main/java/mops/termine2/services/UmfrageService.java
@@ -87,12 +87,12 @@ public class UmfrageService {
 		return null;
 	}
 	
-	public List<Umfrage> loadByErstellerOhneTermine(String ersteller) {
+	public List<Umfrage> loadByErstellerOhneUmfragen(String ersteller) {
 		List<UmfrageDB> umfrageDBs = umfrageRepository.findByErsteller(ersteller);
 		return getDistinctUmfragen(umfrageDBs);
 	}
 	
-	public List<Umfrage> loadByGruppeOhneTermine(String gruppe) {
+	public List<Umfrage> loadByGruppeOhneUmfragen(String gruppe) {
 		List<UmfrageDB> umfrageDBs = umfrageRepository.findByGruppe(gruppe);
 		return getDistinctUmfragen(umfrageDBs);
 	}

--- a/src/main/java/mops/termine2/services/UmfragenuebersichtService.java
+++ b/src/main/java/mops/termine2/services/UmfragenuebersichtService.java
@@ -1,15 +1,14 @@
 package mops.termine2.services;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import mops.termine2.authentication.Account;
 import mops.termine2.models.Gruppe;
 import mops.termine2.models.Umfrage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 public class UmfragenuebersichtService {
@@ -20,13 +19,34 @@ public class UmfragenuebersichtService {
 	@Autowired
 	private GruppeService gruppeService;
 	
-	private List<Umfrage> getUmfragenVonBenutzer(Account account) {
+	public List<Umfrage> loadOffeneUmfragenFuerGruppe(String gruppe) {
 		List<Umfrage> umfragen = new ArrayList<>();
-		List<Gruppe> gruppen = gruppeService.loadByBenutzer(account);
-		for (Gruppe g : gruppen) {
-			umfragen.addAll(umfrageService.loadByGruppeOhneTermine(g.getName()));
+		List<Umfrage> offeneUmfragen = new ArrayList<>();
+		
+		umfragen.addAll(umfrageService.loadByGruppeOhneUmfragen(gruppe));
+		
+		for (Umfrage umfrage : umfragen) {
+			if (umfrage.getFrist().compareTo(LocalDateTime.now()) > 0) {
+				offeneUmfragen.add(umfrage);
+			}
 		}
-		return umfragen;
+		
+		return offeneUmfragen;
+	}
+	
+	public List<Umfrage> loadAbgeschlosseneUmfragenFuerGruppe(String gruppe) {
+		List<Umfrage> umfragen = new ArrayList<>();
+		List<Umfrage> abgeschlosseneUmfragen = new ArrayList<>();
+		
+		umfragen.addAll(umfrageService.loadByGruppeOhneUmfragen(gruppe));
+		
+		for (Umfrage umfrage : umfragen) {
+			if (umfrage.getFrist().compareTo(LocalDateTime.now()) <= 0) {
+				abgeschlosseneUmfragen.add(umfrage);
+			}
+		}
+		
+		return abgeschlosseneUmfragen;
 	}
 	
 	public List<Umfrage> loadOffeneUmfragenFuerBenutzer(Account account) {
@@ -51,4 +71,14 @@ public class UmfragenuebersichtService {
 		return abgeschlosseneUmfragen;
 	}
 	
+	private List<Umfrage> getUmfragenVonBenutzer(Account account) {
+		List<Umfrage> umfragen = new ArrayList<>();
+		List<Gruppe> gruppen = gruppeService.loadByBenutzer(account);
+		for (Gruppe g : gruppen) {
+			umfragen.addAll(umfrageService.loadByGruppeOhneUmfragen(g.getName()));
+		}
+		return umfragen;
+	}
+	
 }
+

--- a/src/main/resources/templates/termine.html
+++ b/src/main/resources/templates/termine.html
@@ -33,13 +33,15 @@
 			<ul>
 				<li>
 					<a th:href="@{/termine2}">
-						<img src="../static/img/resized/calendar_small.jpg" th:src="@{/img/resized/calendar_small.jpg}">
+						<img src="../static/img/resized/calendar_small.jpg"
+						     th:src="@{/img/resized/calendar_small.jpg}">
 						Termine
 					</a>
 				</li>
 				<li>
 					<a th:href="@{/termine2/umfragen}">
-						<img src="../static/img/resized/survey_small.jpg" th:src="@{/img/resized/survey_small.jpg}">
+						<img src="../static/img/resized/survey_small.jpg"
+						     th:src="@{/img/resized/survey_small.jpg}">
 						Umfragen
 					</a>
 				</li>
@@ -60,24 +62,25 @@
 				<div class="btn-toolbar" style="font-size: small">
 					<div class="dropdown">
 						<button class="btn btn-outline-secondary dropdown-toggle mx-2"
-						        data-toggle="dropdown" id="dropOperator" type="button" th:text="${selektierteGruppe}">
+						        data-toggle="dropdown" id="dropOperator" type="button"
+						        th:text="${selektierteGruppe}">
 							Alle Gruppen
 						</button>
 						
 						<!-- Auswählbare Gruppen -->
 						<div class="dropdown-menu" >
-							<a class="dropdown-item" href="#" th:each="gruppe : ${termine.gruppen}"
-							   th:href="@{/termine2(gruppe=${gruppe})}" th:text="${gruppe}"
-							   th:value="${gruppe}">
-								Gruppe
+							<a class="dropdown-item" th:href="@{/termine2}">
+								Alle Gruppen
 							</a>
 							
 							<div th:if="*{termine.gruppen.size() > 0}">
 								<div class="dropdown-divider"></div>
 							</div>
-
-							<a class="dropdown-item" th:href="@{/termine2}">
-								Alle Gruppen
+							
+							<a class="dropdown-item" href="#" th:each="gruppe : ${termine.gruppen}"
+							   th:href="@{/termine2(gruppe=${gruppe})}" th:text="${gruppe}"
+							   th:value="${gruppe}">
+								Gruppe
 							</a>
 						</div>
 					</div>
@@ -190,7 +193,7 @@
 							
 							<!-- Beschreibung -->
 							<div class="mt-2 pb-2 border-bottom" style="font-size: small"
-							     th:if="${termin.beschreibung != null && termin.beschreibung != ''}"
+							     th:if="*{termin.beschreibung != null && termin.beschreibung != ''}"
 							     th:text="${#strings.abbreviate(termin.beschreibung,135)}">
 								Beschreibung
 							</div>
@@ -221,7 +224,7 @@
 										<span class="text-info" th:text="${termin.link}">
 											Link
 										</span>
-									</form>
+									</div>
 								</div>
 							</div>
 						</div>

--- a/src/main/resources/templates/umfragen.html
+++ b/src/main/resources/templates/umfragen.html
@@ -33,13 +33,15 @@
 			<ul>
 				<li>
 					<a th:href="@{/termine2}">
-						<img src="../static/img/resized/calendar_small.jpg" th:src="@{/img/resized/calendar_small.jpg}">
+						<img src="../static/img/resized/calendar_small.jpg"
+						     th:src="@{/img/resized/calendar_small.jpg}">
 						Termine
 					</a>
 				</li>
 				<li>
 					<a th:href="@{/termine2/umfragen}">
-						<img src="../static/img/resized/survey_small.jpg" th:src="@{/img/resized/survey_small.jpg}">
+						<img src="../static/img/resized/survey_small.jpg"
+						     th:src="@{/img/resized/survey_small.jpg}">
 						Umfragen
 					</a>
 				</li>
@@ -60,23 +62,25 @@
 				<div class="btn-toolbar" style="font-size: small">
 					<div class="dropdown">
 						<button class="btn btn-outline-secondary dropdown-toggle mx-2"
-						        data-toggle="dropdown" id="dropOperator" type="button">
+						        data-toggle="dropdown" id="dropOperator" type="button"
+						        th:text="${selektierteGruppe}">
 							Alle Gruppen
 						</button>
 						
 						<!-- Auswählbare Gruppen -->
 						<div class="dropdown-menu">
-							<a class="dropdown-item" href="#" th:each="gruppe : ${umfragen.gruppen}"
-							   th:href="@{/termine2/umfragen(gruppe=${gruppe})}" th:text="${gruppe}">
-								Gruppe
+							<a class="dropdown-item" th:href="@{/termine2/umfragen}">
+								Alle Gruppen
 							</a>
 							
 							<div th:if="*{umfragen.gruppen.size() > 0}">
 								<div class="dropdown-divider"></div>
 							</div>
 							
-							<a class="dropdown-item" th:href="@{/termine2/umfragen}">
-								Alle Gruppen
+							<a class="dropdown-item" href="#" th:each="gruppe : ${umfragen.gruppen}"
+							   th:href="@{/termine2/umfragen(gruppe=${gruppe})}" th:text="${gruppe}"
+							   th:value="${gruppe}">
+								Gruppe
 							</a>
 						</div>
 					</div>
@@ -131,20 +135,28 @@
 							
 							<!-- Beschreibung -->
 							<div class="mt-2 pb-2 border-bottom" style="font-size: small"
+							     th:if="${umfrage.beschreibung != null &&
+							            umfrage.beschreibung != ''}"
 							     th:text="${#strings.abbreviate(umfrage.beschreibung,300)}">
 								Beschreibung
 							</div>
 							
-							<div th:text=" 'Link: ' + ${umfrage.link}"></div>
-							
 							<!-- Weitere Aktionen -->
 							<div class="mt-3" style="text-align: center">
-								<!-- leitet an die Ergebnisse der Umfrage weiter -->
-								<!-- <a th:href="@{………}"> -->
-								<button class="btn btn-outline-info" style="font-size: small">
-									Details
-								</button>
-								<!-- </a> -->
+								<form th:action="@{/termine2/umfragen}" method="post">
+									<button class="btn btn-outline-info" style="font-size: small"
+									        type="submit" name="details" th:value="*{umfrage.link}">
+										Details
+									</button>
+								</form>
+								
+								<div class="mt-2 text-secondary" style="font-size: small">
+									Link:
+									
+									<span class="text-info" th:text="${umfrage.link}">
+										Link
+									</span>
+								</div>
 							</div>
 						</div>
 					</div>
@@ -179,12 +191,12 @@
 							</div>
 							
 							<!-- Beschreibung -->
-							<div class="mt-2 pb-2 border-bottom"
-							     style="font-size: small"
-							     th:text="${#strings.abbreviate(offeneUmfrage.beschreibung,300)}">
+							<div class="mt-2 pb-2 border-bottom" style="font-size: small"
+							     th:if="*{offeneUmfrage.beschreibung != null &&
+							            offeneUmfrage.beschreibung != ''}"
+							     th:text="${#strings.abbreviate(offeneUmfrage.beschreibung,135)}">
 								Beschreibung
 							</div>
-							<div th:text=" 'Link: ' + ${offeneUmfrage.link}"></div>
 							
 							<!-- Weitere Aktionen -->
 							<div class="mt-2">
@@ -196,11 +208,23 @@
 								</div>
 								
 								<div class="mt-2" style="text-align: center">
-									<!-- Falls der Nutzer schon an der Abstimmung teilgenommen hat,
-									     dann btn-outline-info, ansonsten btn-primary. -->
-									<button class="btn btn-outline-info" style="font-size: small">
-										Details
-									</button>
+									<form th:action="@{/termine2/umfragen}" method="post">
+										<!-- Falls der Nutzer schon an der Abstimmung teilgenommen
+										     hat, dann btn-outline-info, ansonsten btn-primary. -->
+										<button class="btn btn-outline-info"
+										        style="font-size: small" type="submit"
+										        name="details" th:value="${offeneUmfrage.link}">
+											Details
+										</button>
+									</form>
+									
+									<div class="mt-2 text-secondary" style="font-size: small">
+										Link:
+										
+										<span class="text-info" th:text="${offeneUmfrage.link}">
+											Link
+										</span>
+									</div>
 								</div>
 							</div>
 						</div>

--- a/src/test/java/mops/termine2/services/UmfrageServiceTest.java
+++ b/src/test/java/mops/termine2/services/UmfrageServiceTest.java
@@ -101,7 +101,7 @@ public class UmfrageServiceTest {
 		Umfrage erwartet = erstelleBeispielUmfrage(anzahl, 0, 0, 0, 0, 0);
 		erwartet.setVorschlaege(new ArrayList<String>());
 		
-		Umfrage ergebnis = service.loadByErstellerOhneTermine(ERSTELLER[0]).get(0);
+		Umfrage ergebnis = service.loadByErstellerOhneUmfragen(ERSTELLER[0]).get(0);
 		
 		assertThat(ergebnis).isEqualTo(erwartet);
 	}
@@ -120,8 +120,8 @@ public class UmfrageServiceTest {
 		Umfrage erwartet2 = erstelleBeispielUmfrage(3, 1, 0, 1, 1, 1);
 		erwartet2.setVorschlaege(new ArrayList<String>());
 		
-		Umfrage ergebnis1 = service.loadByErstellerOhneTermine(ERSTELLER[0]).get(0);
-		Umfrage ergebnis2 = service.loadByErstellerOhneTermine(ERSTELLER[0]).get(1);
+		Umfrage ergebnis1 = service.loadByErstellerOhneUmfragen(ERSTELLER[0]).get(0);
+		Umfrage ergebnis2 = service.loadByErstellerOhneUmfragen(ERSTELLER[0]).get(1);
 		
 		assertThat(erwartet1).isEqualTo(ergebnis1);
 		assertThat(erwartet2).isEqualTo(ergebnis2);
@@ -135,7 +135,7 @@ public class UmfrageServiceTest {
 		Umfrage erwartet = erstelleBeispielUmfrage(anzahl, 0, 0, 0, 0, 0);
 		erwartet.setVorschlaege(new ArrayList<String>());
 		
-		Umfrage ergebnis = service.loadByGruppeOhneTermine(GRUPPE[0]).get(0);
+		Umfrage ergebnis = service.loadByGruppeOhneUmfragen(GRUPPE[0]).get(0);
 		
 		assertThat(ergebnis).isEqualTo(erwartet);
 	}
@@ -154,8 +154,8 @@ public class UmfrageServiceTest {
 		Umfrage erwartet2 = erstelleBeispielUmfrage(3, 1, 1, 0, 1, 1);
 		erwartet2.setVorschlaege(new ArrayList<String>());
 		
-		Umfrage ergebnis1 = service.loadByGruppeOhneTermine(GRUPPE[0]).get(0);
-		Umfrage ergebnis2 = service.loadByGruppeOhneTermine(GRUPPE[0]).get(1);
+		Umfrage ergebnis1 = service.loadByGruppeOhneUmfragen(GRUPPE[0]).get(0);
+		Umfrage ergebnis2 = service.loadByGruppeOhneUmfragen(GRUPPE[0]).get(1);
 		
 		assertThat(erwartet1).isEqualTo(ergebnis1);
 		assertThat(erwartet2).isEqualTo(ergebnis2);


### PR DESCRIPTION
Renamed a falsely named method in 'UmfrageService'
Changed order of options in Gruppenfilter in both Liste UIs

The Umfragen can now be filtered by Gruppen. Additionally, the option
'Alle Gruppen' has been moved to the top for quick access.