### PR TITLE
Terminübersicht

### DIFF
--- a/src/main/java/mops/termine2/controller/TermineUebersichtController.java
+++ b/src/main/java/mops/termine2/controller/TermineUebersichtController.java
@@ -15,13 +15,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.context.annotation.SessionScope;
 
 import javax.annotation.security.RolesAllowed;
-import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
 import java.util.Comparator;
 import java.util.List;
@@ -98,15 +96,5 @@ public class TermineUebersichtController {
 		m.addAttribute("termine", termine);
 		
 		return "termine";
-	}
-	
-	@PostMapping(path = "", params = "details")
-	@RolesAllowed({Konstanten.ROLE_ORGA, Konstanten.ROLE_STUDENTIN})
-	public String details(Principal p, Model m, final HttpServletRequest req) {
-		String link = "";
-		if (p != null) {
-			link = req.getParameter("details");
-		}
-		return "redirect:/termine2/" + link;
 	}
 }

--- a/src/main/resources/templates/termine.html
+++ b/src/main/resources/templates/termine.html
@@ -142,13 +142,12 @@
 							
 							<!-- Weitere Aktionen -->
 							<div class="mt-3" style="text-align: center">
-								<form th:action="@{/termine2}" method="post">
+								<a th:href="@{/termine2/{link}(link=${termin.link})}">
 									<button class="btn btn-outline-info" style="font-size: small"
-									        type="submit" name="details" th:value="*{termin.link}">
+											type="submit" name="details" th:value="*{termin.link}">
 										Details
 									</button>
-								</form>
-								
+								</a>
 								<div class="mt-2 text-secondary" style="font-size: small">
 									Link:
 									
@@ -209,7 +208,7 @@
 								</div>
 								
 								<div class="mt-2" style="text-align: center">
-									<form th:action="@{/termine2}" method="post">
+									<a th:href="@{/termine2/{link}(link=${termin.link})}">
 										<button class="btn btn-outline-info"
 										        style="font-size: small" type="submit"
 										        name="details"
@@ -223,7 +222,7 @@
 												th:if="!${termin.teilgenommen}">
 											Abstimmen
 										</button>
-									</form>
+									</a>
 									
 									<div class="mt-2 text-secondary" style="font-size: small">
 										Link:

--- a/src/main/resources/templates/termine.html
+++ b/src/main/resources/templates/termine.html
@@ -63,7 +63,9 @@
 					<div class="dropdown">
 						<button class="btn btn-outline-secondary dropdown-toggle mx-2"
 						        data-toggle="dropdown" id="dropOperator" type="button"
-						        th:text="${termine.selektierteGruppe.name}  + ' (id: ' + ${termine.selektierteGruppe.id} + ')'">
+						        th:text="${termine.selektierteGruppe.id != -1}?
+						        ${termine.selektierteGruppe.name}  + ' (id: ' + ${termine.selektierteGruppe.id} + ')' :
+						        ${termine.selektierteGruppe.name}">
 							Alle Gruppen
 						</button>
 						


### PR DESCRIPTION
- Termine in der Übersicht werden nur noch angezeigt, wenn man Mitglied in der entsprechenden Gruppe ist.
- Weiterleitung beim Klick auf Details bzw. Abstimmen erfolgt jetzt über einen Link und nicht mehr über einen Post request. Dadurch kann man die Termine in neuen Browser Tabs öffnen.
- Im Gruppenfilter wird die id bei 'Alle Gruppen' nicht mehr angezeigt