### PR TITLE
Authentication rework

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation 'com.github.javafaker:javafaker:1.0.2'
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    testImplementation 'com.c4-soft.springaddons:spring-security-test-keycloack-addons:1.2.0'
 
 }
 

--- a/src/main/java/mops/termine2/services/AuthenticationService.java
+++ b/src/main/java/mops/termine2/services/AuthenticationService.java
@@ -6,35 +6,23 @@ import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
 import org.springframework.stereotype.Service;
 
 import java.security.Principal;
-import java.util.HashSet;
-import java.util.Set;
 
 @Service
 public class AuthenticationService {
 	
 	/**
-	 * Generiert einen Account mit einem KeyCloak Token 
+	 * Generiert einen Account aus einem KeyCloak Token
+	 *
 	 * @param principal Ein java-security Interface welches einen Nutzer representiert
 	 * @return Account
 	 */
 	public Account createAccountFromPrincipal(Principal principal) {
-		if (principal instanceof KeycloakAuthenticationToken) {
-			KeycloakAuthenticationToken token = (KeycloakAuthenticationToken) principal;
-			KeycloakPrincipal keycloakToken = (KeycloakPrincipal) token.getPrincipal();
-			return new Account(
-				keycloakToken.getName(),
-				keycloakToken.getKeycloakSecurityContext().getIdToken().getEmail(),
-				null,
-				token.getAccount().getRoles());
-		} else {
-			Set<String> roles = new HashSet<String>();
-			roles.add("studentin");
-			return new Account(
-				principal.getName(),
-				null,
-				null,
-				roles);
-		}
+		KeycloakAuthenticationToken token = (KeycloakAuthenticationToken) principal;
+		KeycloakPrincipal keycloakToken = (KeycloakPrincipal) token.getPrincipal();
+		return new Account(
+			keycloakToken.getName(),
+			keycloakToken.getKeycloakSecurityContext().getIdToken().getEmail(),
+			null,
+			token.getAccount().getRoles());
 	}
-	
 }

--- a/src/test/java/mops/termine2/controller/TerminAbstimmungControllerTest.java
+++ b/src/test/java/mops/termine2/controller/TerminAbstimmungControllerTest.java
@@ -13,7 +13,7 @@ public class TerminAbstimmungControllerTest {
 	transient MockMvc mvc;
 	/*
 	@Test
-	@WithMockUser(roles = {Konstanten.STUDENTIN})
+	@WithMockKeycloackAuth(name = "studentin", roles = "studentin")
 	void testTermineAbstimmung() throws Exception {
 		mvc.perform(get("/termine2/termine-abstimmung")).andExpect(status().isOk());
 	}

--- a/src/test/java/mops/termine2/controller/TerminAbstimmungControllerTest.java
+++ b/src/test/java/mops/termine2/controller/TerminAbstimmungControllerTest.java
@@ -13,7 +13,7 @@ public class TerminAbstimmungControllerTest {
 	transient MockMvc mvc;
 	/*
 	@Test
-	@WithMockKeycloackAuth(name = "studentin", roles = "studentin")
+	@WithMockKeycloackAuth(name = Konstanten.STUDENTIN, roles = Konstanten.STUDENTIN)
 	void testTermineAbstimmung() throws Exception {
 		mvc.perform(get("/termine2/termine-abstimmung")).andExpect(status().isOk());
 	}

--- a/src/test/java/mops/termine2/controller/TerminNeuControllerTest.java
+++ b/src/test/java/mops/termine2/controller/TerminNeuControllerTest.java
@@ -1,11 +1,10 @@
 package mops.termine2.controller;
 
-import mops.termine2.Konstanten;
+import com.c4_soft.springaddons.test.security.context.support.WithMockKeycloackAuth;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -19,7 +18,7 @@ public class TerminNeuControllerTest {
 	transient MockMvc mvc;
 	
 	@Test
-	@WithMockUser(roles = {Konstanten.STUDENTIN})
+	@WithMockKeycloackAuth(name = "studentin", roles = "studentin")
 	void testTerminNeu() throws Exception {
 		mvc.perform(get("/termine2/termine-neu")).andExpect(status().isOk());
 	}

--- a/src/test/java/mops/termine2/controller/TerminNeuControllerTest.java
+++ b/src/test/java/mops/termine2/controller/TerminNeuControllerTest.java
@@ -1,6 +1,7 @@
 package mops.termine2.controller;
 
 import com.c4_soft.springaddons.test.security.context.support.WithMockKeycloackAuth;
+import mops.termine2.Konstanten;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -18,7 +19,7 @@ public class TerminNeuControllerTest {
 	transient MockMvc mvc;
 	
 	@Test
-	@WithMockKeycloackAuth(name = "studentin", roles = "studentin")
+	@WithMockKeycloackAuth(name = Konstanten.STUDENTIN, roles = Konstanten.STUDENTIN)
 	void testTerminNeu() throws Exception {
 		mvc.perform(get("/termine2/termine-neu")).andExpect(status().isOk());
 	}

--- a/src/test/java/mops/termine2/controller/TermineUebersichtControllerTest.java
+++ b/src/test/java/mops/termine2/controller/TermineUebersichtControllerTest.java
@@ -1,11 +1,10 @@
 package mops.termine2.controller;
 
-import mops.termine2.Konstanten;
+import com.c4_soft.springaddons.test.security.context.support.WithMockKeycloackAuth;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -19,7 +18,7 @@ public class TermineUebersichtControllerTest {
 	transient MockMvc mvc;
 	
 	@Test
-	@WithMockUser(roles = {Konstanten.STUDENTIN})
+	@WithMockKeycloackAuth(name = "studentin", roles = "studentin")
 	void testIndex() throws Exception {
 		mvc.perform(get("/termine2")).andExpect(status().isOk());
 	}

--- a/src/test/java/mops/termine2/controller/TermineUebersichtControllerTest.java
+++ b/src/test/java/mops/termine2/controller/TermineUebersichtControllerTest.java
@@ -1,6 +1,7 @@
 package mops.termine2.controller;
 
 import com.c4_soft.springaddons.test.security.context.support.WithMockKeycloackAuth;
+import mops.termine2.Konstanten;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -18,7 +19,7 @@ public class TermineUebersichtControllerTest {
 	transient MockMvc mvc;
 	
 	@Test
-	@WithMockKeycloackAuth(name = "studentin", roles = "studentin")
+	@WithMockKeycloackAuth(name = Konstanten.STUDENTIN, roles = Konstanten.STUDENTIN)
 	void testIndex() throws Exception {
 		mvc.perform(get("/termine2")).andExpect(status().isOk());
 	}

--- a/src/test/java/mops/termine2/controller/UmfragenAbstimmungControllerTest.java
+++ b/src/test/java/mops/termine2/controller/UmfragenAbstimmungControllerTest.java
@@ -1,11 +1,10 @@
 package mops.termine2.controller;
 
-import mops.termine2.Konstanten;
+import com.c4_soft.springaddons.test.security.context.support.WithMockKeycloackAuth;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -19,7 +18,7 @@ public class UmfragenAbstimmungControllerTest {
 	transient MockMvc mvc;
 	
 	@Test
-	@WithMockUser(roles = {Konstanten.STUDENTIN})
+	@WithMockKeycloackAuth(name = "studentin", roles = "studentin")
 	void testUmfragenAbstmmung() throws Exception {
 		mvc.perform(get("/termine2/umfragen-abstimmung")).andExpect(status().isOk());
 	}

--- a/src/test/java/mops/termine2/controller/UmfragenAbstimmungControllerTest.java
+++ b/src/test/java/mops/termine2/controller/UmfragenAbstimmungControllerTest.java
@@ -1,6 +1,7 @@
 package mops.termine2.controller;
 
 import com.c4_soft.springaddons.test.security.context.support.WithMockKeycloackAuth;
+import mops.termine2.Konstanten;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -18,7 +19,7 @@ public class UmfragenAbstimmungControllerTest {
 	transient MockMvc mvc;
 	
 	@Test
-	@WithMockKeycloackAuth(name = "studentin", roles = "studentin")
+	@WithMockKeycloackAuth(name = Konstanten.STUDENTIN, roles = Konstanten.STUDENTIN)
 	void testUmfragenAbstmmung() throws Exception {
 		mvc.perform(get("/termine2/umfragen-abstimmung")).andExpect(status().isOk());
 	}

--- a/src/test/java/mops/termine2/controller/UmfragenNeuControllerTest.java
+++ b/src/test/java/mops/termine2/controller/UmfragenNeuControllerTest.java
@@ -1,6 +1,7 @@
 package mops.termine2.controller;
 
 import com.c4_soft.springaddons.test.security.context.support.WithMockKeycloackAuth;
+import mops.termine2.Konstanten;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -18,7 +19,7 @@ public class UmfragenNeuControllerTest {
 	transient MockMvc mvc;
 	
 	@Test
-	@WithMockKeycloackAuth(name = "studentin", roles = "studentin")
+	@WithMockKeycloackAuth(name = Konstanten.STUDENTIN, roles = Konstanten.STUDENTIN)
 	void testUmfrageNeu() throws Exception {
 		mvc.perform(get("/termine2/umfragen-neu")).andExpect(status().isOk());
 	}

--- a/src/test/java/mops/termine2/controller/UmfragenNeuControllerTest.java
+++ b/src/test/java/mops/termine2/controller/UmfragenNeuControllerTest.java
@@ -1,11 +1,10 @@
 package mops.termine2.controller;
 
-import mops.termine2.Konstanten;
+import com.c4_soft.springaddons.test.security.context.support.WithMockKeycloackAuth;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -19,7 +18,7 @@ public class UmfragenNeuControllerTest {
 	transient MockMvc mvc;
 	
 	@Test
-	@WithMockUser(roles = {Konstanten.STUDENTIN})
+	@WithMockKeycloackAuth(name = "studentin", roles = "studentin")
 	void testUmfrageNeu() throws Exception {
 		mvc.perform(get("/termine2/umfragen-neu")).andExpect(status().isOk());
 	}

--- a/src/test/java/mops/termine2/controller/UmfragenUebersichtControllerTest.java
+++ b/src/test/java/mops/termine2/controller/UmfragenUebersichtControllerTest.java
@@ -1,6 +1,7 @@
 package mops.termine2.controller;
 
 import com.c4_soft.springaddons.test.security.context.support.WithMockKeycloackAuth;
+import mops.termine2.Konstanten;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -18,7 +19,7 @@ public class UmfragenUebersichtControllerTest {
 	transient MockMvc mvc;
 	
 	@Test
-	@WithMockKeycloackAuth(name = "studentin", roles = "studentin")
+	@WithMockKeycloackAuth(name = Konstanten.STUDENTIN, roles = Konstanten.STUDENTIN)
 	void testUmfragen() throws Exception {
 		mvc.perform(get("/termine2/umfragen")).andExpect(status().isOk());
 	}

--- a/src/test/java/mops/termine2/controller/UmfragenUebersichtControllerTest.java
+++ b/src/test/java/mops/termine2/controller/UmfragenUebersichtControllerTest.java
@@ -1,11 +1,10 @@
 package mops.termine2.controller;
 
-import mops.termine2.Konstanten;
+import com.c4_soft.springaddons.test.security.context.support.WithMockKeycloackAuth;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -19,7 +18,7 @@ public class UmfragenUebersichtControllerTest {
 	transient MockMvc mvc;
 	
 	@Test
-	@WithMockUser(roles = {Konstanten.STUDENTIN})
+	@WithMockKeycloackAuth(name = "studentin", roles = "studentin")
 	void testUmfragen() throws Exception {
 		mvc.perform(get("/termine2/umfragen")).andExpect(status().isOk());
 	}


### PR DESCRIPTION
Controller Tests nutzen jetzt einen Keycloak Authentication Token, sodass die Rollen in der Annotation angegeben werden können. Vorher waren die Rollen im Auth Service hard coded.