### PR TITLE
Gruppe scheduler url fix

### DIFF
--- a/src/main/java/mops/termine2/scheduling/GruppeScheduler.java
+++ b/src/main/java/mops/termine2/scheduling/GruppeScheduler.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.logging.Logger;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -30,7 +31,8 @@ public class GruppeScheduler {
 	
 	private int statusnummer = 0;
 	
-	private final String url = "http://localhost:8082/gruppen2/api/updateGroups/{status}";
+	@Value("${termine2.gruppescheduler.url}")
+	private String urlPrefix;
 	
 	private RestTemplate template;
 	
@@ -46,7 +48,8 @@ public class GruppeScheduler {
 	
 	@Scheduled(fixedDelay = 30000)
 	public void updateGruppe() {
-		logger.info("Update der Gruppen");
+		String url = urlPrefix + "/gruppen2/api/updateGroups/{status}";
+		logger.info("Hole Gruppenupdate von " + url.replace("{status}", Integer.toString(statusnummer)));
 		ResponseEntity<GruppenDTO> result;
 		try {
 			result = template.getForEntity(url, GruppenDTO.class, statusnummer);

--- a/src/main/java/mops/termine2/scheduling/GruppeScheduler.java
+++ b/src/main/java/mops/termine2/scheduling/GruppeScheduler.java
@@ -32,7 +32,7 @@ public class GruppeScheduler {
 	private int statusnummer = 0;
 	
 	@Value("${termine2.gruppescheduler.url}")
-	private String urlPrefix;
+	private String urlPrefix = "http://localhost:8082";
 	
 	private RestTemplate template;
 	

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,6 @@ keycloak.resource=demo
 keycloak.public-client=true
 management.endpoints.web.exposure.include=info,health,prometheus
 management.endpoint.prometheus.enabled=true
+
+# URL, unter der die Anwendung gruppe2 zu finden ist. Hier werden die Gruppenupdates geholt
+termine2.gruppescheduler.url=http://localhost:8082

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -11,3 +11,5 @@ spring.datasource.username=root
 spring.datasource.password=geheim
 management.endpoints.web.exposure.include=info,health,prometheus
 management.endpoint.prometheus.enabled=true
+
+termine2.gruppescheduler.url=http://localhost:8082


### PR DESCRIPTION
- URL, unter der die API der gruppe2 erreichbar ist, wurde in die application.properties ausgelagert, damit man später nichts im Code ändern muss