### PR TITLE
Added .gitattributes file to ensure Windows users can start the prod dockerfile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Bitte zwei Leute testen, wobei einer Linux und einer Windows benutzt.
Um richtig zu testen müsste man das bestehende Repository löschen, diesen einen branch mittels
`git clone --single-branch --branch shellFixForWindoof https://github.com/hhu-propra2/abschlussprojekt-fixlater.git` 
klonen, und anschließend im Repository
`docker-compose -f docker-compose-prod.yml up --build`
ausführen. Dann sollte Docker beim Starten der wait-for-it.sh keine Probleme anzeigen und Spring gestartet werden.