### PR TITLE
Fixed critical bug in Umfrageergebnis Service

### DIFF
--- a/src/main/java/mops/termine2/controller/formular/AntwortForm.java
+++ b/src/main/java/mops/termine2/controller/formular/AntwortForm.java
@@ -10,7 +10,7 @@ import mops.termine2.util.LocalDateTimeManager;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 @Data
@@ -30,7 +30,7 @@ public class AntwortForm {
 	
 	
 	public void init(TerminfindungAntwort terminAbstimmung) {
-		HashMap<LocalDateTime, Antwort> antwortenMap = terminAbstimmung.getAntworten();
+		LinkedHashMap<LocalDateTime, Antwort> antwortenMap = terminAbstimmung.getAntworten();
 		pseudonym = terminAbstimmung.getPseudonym();
 		benutzer = terminAbstimmung.getKuerzel();
 		
@@ -62,7 +62,7 @@ public class AntwortForm {
 		}
 		
 		
-		HashMap<LocalDateTime, Antwort> antwortenMap = new HashMap<>();
+		LinkedHashMap<LocalDateTime, Antwort> antwortenMap = new LinkedHashMap<>();
 		for (int i = 0; i < termine.size(); i++) {
 			antwortenMap.put(termine.get(i), antworten.get(i));
 		}

--- a/src/main/java/mops/termine2/controller/formular/AntwortFormUmfragen.java
+++ b/src/main/java/mops/termine2/controller/formular/AntwortFormUmfragen.java
@@ -8,7 +8,7 @@ import mops.termine2.models.Umfrage;
 import mops.termine2.models.UmfrageAntwort;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 @Data
@@ -41,7 +41,7 @@ public class AntwortFormUmfragen {
 			return null;
 		}
 		
-		HashMap<String, Antwort> antwortenMap = new HashMap<>();
+		LinkedHashMap<String, Antwort> antwortenMap = new LinkedHashMap<>();
 		for (int i = 0; i < vorschlaege.size(); i++) {
 			antwortenMap.put(vorschlaege.get(i), antworten.get(i));
 		}
@@ -51,7 +51,7 @@ public class AntwortFormUmfragen {
 	}
 	
 	public void init(UmfrageAntwort umfrageAntwort) {
-		HashMap<String, Antwort> antwortenMap = umfrageAntwort.getAntworten();
+		LinkedHashMap<String, Antwort> antwortenMap = umfrageAntwort.getAntworten();
 		pseudonym = umfrageAntwort.getPseudonym();
 		benutzer = umfrageAntwort.getBenutzer();
 		

--- a/src/main/java/mops/termine2/models/TerminfindungAntwort.java
+++ b/src/main/java/mops/termine2/models/TerminfindungAntwort.java
@@ -7,7 +7,7 @@ import lombok.ToString;
 import mops.termine2.enums.Antwort;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 @Getter
 @Setter
@@ -19,7 +19,7 @@ public class TerminfindungAntwort {
 	
 	private String kuerzel;
 	
-	private HashMap<LocalDateTime, Antwort> antworten;
+	private LinkedHashMap<LocalDateTime, Antwort> antworten;
 	
 	private String pseudonym;
 	

--- a/src/main/java/mops/termine2/models/UmfrageAntwort.java
+++ b/src/main/java/mops/termine2/models/UmfrageAntwort.java
@@ -1,6 +1,6 @@
 package mops.termine2.models;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -18,7 +18,7 @@ public class UmfrageAntwort {
 	
 	private String benutzer;
 	
-	private HashMap<String, Antwort> antworten;
+	private LinkedHashMap<String, Antwort> antworten;
 	
 	private String pseudonym;
 	

--- a/src/main/java/mops/termine2/services/TerminAntwortService.java
+++ b/src/main/java/mops/termine2/services/TerminAntwortService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
 
@@ -142,11 +142,11 @@ public class TerminAntwortService {
 			antwort.setPseudonym(benutzer);
 		}
 		
-		HashMap<LocalDateTime, Antwort> alteAntwortenMap = new HashMap<>();
+		LinkedHashMap<LocalDateTime, Antwort> alteAntwortenMap = new LinkedHashMap<>();
 		for (TerminfindungAntwortDB alteAntwort : alteAntworten) {
 			alteAntwortenMap.put(alteAntwort.getTerminfindung().getTermin(), alteAntwort.getAntwort());
 		}
-		HashMap<LocalDateTime, Antwort> antwortenMap = new HashMap<>();
+		LinkedHashMap<LocalDateTime, Antwort> antwortenMap = new LinkedHashMap<>();
 		
 		for (TerminfindungDB antwortMoglichkeit : antwortMoglichkeiten) {
 			LocalDateTime termin = antwortMoglichkeit.getTermin();

--- a/src/main/java/mops/termine2/services/TerminErgebnisService.java
+++ b/src/main/java/mops/termine2/services/TerminErgebnisService.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 @Service
@@ -109,7 +109,7 @@ public class TerminErgebnisService {
 		
 		String ergebnis = "eine Zeit";
 		
-		HashMap<LocalDateTime, Antwort> nutzerAntwortenMap = nutzerAbstimmung.getAntworten();
+		LinkedHashMap<LocalDateTime, Antwort> nutzerAntwortenMap = nutzerAbstimmung.getAntworten();
 		termine = terminfindung.getVorschlaege();
 		LocalDateTimeManager.sortTermine(termine);
 		anzahlAntworten = antworten.size();
@@ -131,7 +131,7 @@ public class TerminErgebnisService {
 			
 			nutzerAntworten.add(nutzerAntwortenMap.get(localDateTime));
 			for (TerminfindungAntwort antwort : antworten) {
-				HashMap<LocalDateTime, Antwort> antwortMap = antwort.getAntworten();
+				LinkedHashMap<LocalDateTime, Antwort> antwortMap = antwort.getAntworten();
 				Antwort a = antwortMap.get(localDateTime);
 				String pseudonym = antwort.getPseudonym();
 				if (a == Antwort.JA) {

--- a/src/main/java/mops/termine2/services/UmfrageAntwortService.java
+++ b/src/main/java/mops/termine2/services/UmfrageAntwortService.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
 
@@ -133,12 +133,12 @@ public class UmfrageAntwortService {
 			antwort.setPseudonym(benutzer);
 		}
 		
-		HashMap<String, Antwort> alteAntwortenMap = new HashMap<>();
+		LinkedHashMap<String, Antwort> alteAntwortenMap = new LinkedHashMap<>();
 		for (UmfrageAntwortDB alteAntwort : alteAntworten) {
 			alteAntwortenMap.put(alteAntwort.getUmfrage().getAuswahlmoeglichkeit(),
 				alteAntwort.getAntwort());
 		}
-		HashMap<String, Antwort> antwortenMap = new HashMap<>();
+		LinkedHashMap<String, Antwort> antwortenMap = new LinkedHashMap<>();
 		
 		for (UmfrageDB antwortMoglichkeit : antwortMoglichkeiten) {
 			String vorschalg = antwortMoglichkeit.getAuswahlmoeglichkeit();

--- a/src/main/java/mops/termine2/services/UmfrageErgebnisService.java
+++ b/src/main/java/mops/termine2/services/UmfrageErgebnisService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 @Service
@@ -82,7 +82,7 @@ public class UmfrageErgebnisService {
 		
 		String ergebnis = "ein Vorschlag";
 		
-		HashMap<String, Antwort> nutzerAntwortenMap = nutzerAbstimmung.getAntworten();
+		LinkedHashMap<String, Antwort> nutzerAntwortenMap = nutzerAbstimmung.getAntworten();
 		vorschlaege = umfrage.getVorschlaege();
 		anzahlAntworten = antworten.size();
 		
@@ -97,7 +97,7 @@ public class UmfrageErgebnisService {
 			
 			nutzerAntworten.add(nutzerAntwortenMap.get(vorschlag));
 			for (UmfrageAntwort antwort : antworten) {
-				HashMap<String, Antwort> antwortMap = antwort.getAntworten();
+				LinkedHashMap<String, Antwort> antwortMap = antwort.getAntworten();
 				Antwort a = antwortMap.get(vorschlag);
 				String pseudonym = antwort.getPseudonym();
 				if (a == Antwort.JA) {

--- a/src/test/java/mops/termine2/controller/TerminAbstimmungControllerTest.java
+++ b/src/test/java/mops/termine2/controller/TerminAbstimmungControllerTest.java
@@ -21,7 +21,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -284,7 +284,7 @@ public class TerminAbstimmungControllerTest {
 	
 	private TerminfindungAntwort initAntwort() {
 		TerminfindungAntwort antwort = new TerminfindungAntwort();
-		HashMap<LocalDateTime, Antwort> antwortHashMap = new HashMap<>();
+		LinkedHashMap<LocalDateTime, Antwort> antwortHashMap = new LinkedHashMap<>();
 		antwortHashMap.put(LocalDateTime.of(1, 1, 1, 1, 1), Antwort.VIELLEICHT);
 		antwort.setAntworten(antwortHashMap);
 		antwort.setPseudonym("aha");

--- a/src/test/java/mops/termine2/controller/UmfragenAbstimmungControllerTest.java
+++ b/src/test/java/mops/termine2/controller/UmfragenAbstimmungControllerTest.java
@@ -21,7 +21,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -263,7 +263,7 @@ public class UmfragenAbstimmungControllerTest {
 	
 	private UmfrageAntwort initAntwort() {
 		UmfrageAntwort antwort = new UmfrageAntwort();
-		HashMap<String, Antwort> antwortHashMap = new HashMap<>();
+		LinkedHashMap<String, Antwort> antwortHashMap = new LinkedHashMap<>();
 		antwortHashMap.put("vorschlag", Antwort.JA);
 		antwort.setAntworten(antwortHashMap);
 		antwort.setPseudonym("pseudonym");

--- a/src/test/java/mops/termine2/services/TerminfindungAntwortServiceTest.java
+++ b/src/test/java/mops/termine2/services/TerminfindungAntwortServiceTest.java
@@ -13,7 +13,7 @@ import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -125,8 +125,8 @@ public class TerminfindungAntwortServiceTest {
 		return terminfindungAntwort;
 	}
 	
-	private HashMap<LocalDateTime, Antwort> getBeispielAntwortenAlleJa(int anzahl) {
-		HashMap<LocalDateTime, Antwort> antworten = new HashMap<>();
+	private LinkedHashMap<LocalDateTime, Antwort> getBeispielAntwortenAlleJa(int anzahl) {
+		LinkedHashMap<LocalDateTime, Antwort> antworten = new LinkedHashMap<>();
 		for (int j = 0; j < anzahl; j++) {
 			antworten.put(LocalDateTime.of(1, 1, 1, 1, 1, 1, 1).plusDays(j), Antwort.JA);
 		}
@@ -145,7 +145,7 @@ public class TerminfindungAntwortServiceTest {
 	
 	private List<TerminfindungAntwortDB> getBeispielAntwortDBList(int anzahl, String benutzer) {
 		List<TerminfindungAntwortDB> antwortDBs = new ArrayList<>();
-		HashMap<LocalDateTime, Antwort> antworten = getBeispielAntwortenAlleJa(anzahl);
+		LinkedHashMap<LocalDateTime, Antwort> antworten = getBeispielAntwortenAlleJa(anzahl);
 		for (LocalDateTime termin : antworten.keySet()) {
 			TerminfindungAntwortDB antwortDB = new TerminfindungAntwortDB();
 			TerminfindungDB terminDB = new TerminfindungDB();

--- a/src/test/java/mops/termine2/services/UmfrageAntwortServiceTest.java
+++ b/src/test/java/mops/termine2/services/UmfrageAntwortServiceTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -126,8 +126,8 @@ public class UmfrageAntwortServiceTest {
 		return umfrageAntwort;
 	}
 	
-	private HashMap<String, Antwort> getBeispielAntwortenAlleJa(int anzahl) {
-		HashMap<String, Antwort> antworten = new HashMap<>();
+	private LinkedHashMap<String, Antwort> getBeispielAntwortenAlleJa(int anzahl) {
+		LinkedHashMap<String, Antwort> antworten = new LinkedHashMap<>();
 		for (int j = 0; j < anzahl; j++) {
 			String antwort = Integer.toString(j);
 			antworten.put(antwort, Antwort.JA);
@@ -147,7 +147,7 @@ public class UmfrageAntwortServiceTest {
 	
 	private List<UmfrageAntwortDB> getBeispielAntwortDBList(int anzahl, String benutzer) {
 		List<UmfrageAntwortDB> antwortDBs = new ArrayList<>();
-		HashMap<String, Antwort> antworten = getBeispielAntwortenAlleJa(anzahl);
+		LinkedHashMap<String, Antwort> antworten = getBeispielAntwortenAlleJa(anzahl);
 		for (String vorschlag : antworten.keySet()) {
 			UmfrageAntwortDB antwortDB = new UmfrageAntwortDB();
 			UmfrageDB umfrageDB = new UmfrageDB();


### PR DESCRIPTION
The order of the Vorschläge in the _Umfrageergebnis UI_ did not correspond to the order of the answers, which led to a **faulty mapping** being displayed in the browser.

The _Umfrageergebnis UI_ receives its Vorschläge and answers inside of an _Umfrageergebnis Form_, which in turn is being constructed inside of the _Umfrageabstimmung Controller_. Finally, the construction takes place inside of the _Umfrageergebnis Service_.

Upon inspection, the _Umfrageergebnis Service_ employs a **Hash Map** to store the answers and the Vorschläge which they belong to. Since a Hash Map is using the objects' hash for storage, the **resulting order is very likely to change** as new elements are inserted.

The solution to this was to replace the Hash Map with a **Linked Hash Map**, which **retains the order** in which elements are inserted.