### PR TITLE
Changed DatabaseInitializer to create Links from regex

### DIFF
--- a/src/main/java/mops/termine2/database/DatabaseInitializer.java
+++ b/src/main/java/mops/termine2/database/DatabaseInitializer.java
@@ -46,7 +46,9 @@ public class DatabaseInitializer implements ServletContextInitializer {
 	
 	private static final int MAX_ANZAHL_KOMMENTARE = 3;
 	
-	private static final String LINK_REGEX = "[a-zA-Z0-9]{2,3}[a-zA-Z0-9-]{1,4}[a-zA-Z0-9]{2,3}";
+	private static final String LINK_REGEX = "[a-zA-Z0-9]{2,3}[a-zA-Z0-9-]{1,4}[a-zA-Z0-9]{2,3}--";
+	
+	private static final AtomicInteger COUNTER = new AtomicInteger(0);
 	
 	private static final boolean EINGESCHALTET = false;
 	
@@ -145,7 +147,7 @@ public class DatabaseInitializer implements ServletContextInitializer {
 		AtomicInteger i = new AtomicInteger(1);
 		
 		String beschreibung = faker.lorem().sentence();
-		String link = faker.regexify(LINK_REGEX);
+		String link = faker.regexify(LINK_REGEX) + COUNTER.getAndIncrement();
 		String ort = faker.address().cityName();
 		String titel = faker.friends().quote();
 		LocalDateTime frist = setzeDatumZukunftOderVergangenheit(entscheidungswert);
@@ -206,7 +208,7 @@ public class DatabaseInitializer implements ServletContextInitializer {
 		AtomicInteger i = new AtomicInteger(1);
 		
 		String beschreibung = faker.lorem().sentence();
-		String link = faker.regexify(LINK_REGEX);
+		String link = faker.regexify(LINK_REGEX) + COUNTER.getAndIncrement();
 		String ort = faker.address().cityName();
 		String titel = faker.friends().quote();
 		LocalDateTime frist = LocalDateTime.now().plusDays(r.nextInt(90))
@@ -276,7 +278,7 @@ public class DatabaseInitializer implements ServletContextInitializer {
 		AtomicInteger i = new AtomicInteger(1);
 		
 		String beschreibung = faker.lorem().sentence();
-		String link = faker.regexify(LINK_REGEX);
+		String link = faker.regexify(LINK_REGEX) + COUNTER.getAndIncrement();
 		String titel = faker.friends().quote();
 		Long maxAntwortAnzahl = ThreadLocalRandom.current().nextLong(1, ANZAHL_OPTIONEN);
 		LocalDateTime frist = setzeDatumZukunftOderVergangenheit(entscheidungswert);
@@ -329,7 +331,7 @@ public class DatabaseInitializer implements ServletContextInitializer {
 		AtomicInteger i = new AtomicInteger(1);
 		
 		String beschreibung = faker.lorem().sentence();
-		String link = faker.regexify(LINK_REGEX);
+		String link = faker.regexify(LINK_REGEX) + COUNTER.getAndIncrement();
 		String titel = faker.friends().quote();
 		Long maxAntwortAnzahl = ThreadLocalRandom.current().nextLong(1, ANZAHL_OPTIONEN);
 		LocalDateTime frist = LocalDateTime.now().plusDays(r.nextInt(90))

--- a/src/main/java/mops/termine2/database/DatabaseInitializer.java
+++ b/src/main/java/mops/termine2/database/DatabaseInitializer.java
@@ -46,6 +46,8 @@ public class DatabaseInitializer implements ServletContextInitializer {
 	
 	private static final int MAX_ANZAHL_KOMMENTARE = 3;
 	
+	private static final String LINK_REGEX = "[a-zA-Z0-9]{2,3}[a-zA-Z0-9-]{1,4}[a-zA-Z0-9]{2,3}";
+	
 	private static final boolean EINGESCHALTET = false;
 	
 	private final Logger logger = Logger.getLogger(DatabaseInitializer.class.getName());
@@ -143,7 +145,7 @@ public class DatabaseInitializer implements ServletContextInitializer {
 		AtomicInteger i = new AtomicInteger(1);
 		
 		String beschreibung = faker.lorem().sentence();
-		String link = faker.name().firstName() + benutzerGruppeDB.getId();
+		String link = faker.regexify(LINK_REGEX);
 		String ort = faker.address().cityName();
 		String titel = faker.friends().quote();
 		LocalDateTime frist = setzeDatumZukunftOderVergangenheit(entscheidungswert);
@@ -204,7 +206,7 @@ public class DatabaseInitializer implements ServletContextInitializer {
 		AtomicInteger i = new AtomicInteger(1);
 		
 		String beschreibung = faker.lorem().sentence();
-		String link = faker.funnyName().name();
+		String link = faker.regexify(LINK_REGEX);
 		String ort = faker.address().cityName();
 		String titel = faker.friends().quote();
 		LocalDateTime frist = LocalDateTime.now().plusDays(r.nextInt(90))
@@ -274,7 +276,7 @@ public class DatabaseInitializer implements ServletContextInitializer {
 		AtomicInteger i = new AtomicInteger(1);
 		
 		String beschreibung = faker.lorem().sentence();
-		String link = faker.name().firstName() + benutzerGruppeDB.getId();
+		String link = faker.regexify(LINK_REGEX);
 		String titel = faker.friends().quote();
 		Long maxAntwortAnzahl = ThreadLocalRandom.current().nextLong(1, ANZAHL_OPTIONEN);
 		LocalDateTime frist = setzeDatumZukunftOderVergangenheit(entscheidungswert);
@@ -327,7 +329,7 @@ public class DatabaseInitializer implements ServletContextInitializer {
 		AtomicInteger i = new AtomicInteger(1);
 		
 		String beschreibung = faker.lorem().sentence();
-		String link = faker.funnyName().name();
+		String link = faker.regexify(LINK_REGEX);
 		String titel = faker.friends().quote();
 		Long maxAntwortAnzahl = ThreadLocalRandom.current().nextLong(1, ANZAHL_OPTIONEN);
 		LocalDateTime frist = LocalDateTime.now().plusDays(r.nextInt(90))


### PR DESCRIPTION
Zur Zeit kann es vorkommen, dass Namen wie "René123" als Link gespeichert werden im DatabaseInitializer. Dieser Link entspricht nicht der Regular Expression für gültige Links, insbesondere wird das "é" im Browser ersetzt durch "%E9", sodass der Link auch nicht in der Datenbank gefunden wird und man somit einen 404 Fehler erhält, auch wenn die Umfrage/Terminfindung gültig ist.
Somit können also Umfragen und Terminfindungen erstellt werden, die nie erreichbar sind.

Im Pullrequest wurde die Erstellung eines Links zu faker.regexify geändert, der einen 5-10 Zeichen langen String aus den erlaubten Zeichen erstellt, und die Bindestriche nur in der Mitte stehen können, da ein Link nur aus Bindestrichen nicht schön ist.