### PR TITLE
Tweaked Liste UIs

### DIFF
--- a/src/main/java/mops/termine2/models/Umfrage.java
+++ b/src/main/java/mops/termine2/models/Umfrage.java
@@ -35,8 +35,6 @@ public class Umfrage {
 	
 	private Long maxAntwortAnzahl;
 	
-	private String umfragenErgebnis;
-	
 	private boolean teilgenommen = false;
 	
 	private String ergebnis;

--- a/src/main/resources/templates/termine-neu.html
+++ b/src/main/resources/templates/termine-neu.html
@@ -137,7 +137,7 @@
 								<optgroup label="Gruppen">
 									<option th:each="gruppe, iter : ${gruppen}"
 									        th:value="${gruppen[__${iter.index}__].id}"
-									        th:text="${gruppe.name}">
+									        th:text="${gruppe.name} + ' (' + ${gruppe.id} + ')'">
 										Gruppe
 									</option>
 								</optgroup>

--- a/src/main/resources/templates/termine-neu.html
+++ b/src/main/resources/templates/termine-neu.html
@@ -137,7 +137,7 @@
 								<optgroup label="Gruppen">
 									<option th:each="gruppe, iter : ${gruppen}"
 									        th:value="${gruppen[__${iter.index}__].id}"
-									        th:text="${gruppe.name} + ' (' + ${gruppe.id} + ')'">
+									        th:text="${gruppe.name} + ' (ID: ' + ${gruppe.id} + ')'">
 										Gruppe
 									</option>
 								</optgroup>

--- a/src/main/resources/templates/termine.html
+++ b/src/main/resources/templates/termine.html
@@ -166,11 +166,16 @@
 										   th:text="${#strings.abbreviate(termin.titel, 38)}">
 											Titel mit Tooltip</a></h3>
 									
-									<div class="col-sm-3 mb-auto text-success"
-									     style="text-align: right"
-									     th:text="'am ' + ${#temporals.format(termin.ergebnis,
-									              'dd.MM.yyyy HH:mm')} + ' Uhr'">
-										am DD.MM.YYYY, HH:MM</div>
+									<div class="col-sm-4 mb-auto text-success"
+									     style="text-align: right">
+										<div th:text="'am ' + ${#temporals.format(termin.ergebnis,
+										              'dd.MM.yyyy')}">
+											am dd.MM.yyyy</div>
+										
+										<div th:text="'um ' + ${#temporals.format(termin.ergebnis,
+										              'HH:mm')} + ' Uhr'">
+											um HH:mm</div>
+									</div>
 								</div>
 								
 								<div class="text-break" style="font-size: large"

--- a/src/main/resources/templates/termine.html
+++ b/src/main/resources/templates/termine.html
@@ -9,20 +9,35 @@
 	<title>Termine</title>
 	<th:block th:fragment="headcontent">
 		<!-- Links, Scripts, Styles -->
-		<link rel="stylesheet"
-		      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
-		      integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
-		      crossorigin="anonymous">
 		
-		<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
-		        integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+		<!-- jQuery -->
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"
+		        integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
 		        crossorigin="anonymous"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"
-		        integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q"
+		
+		<!-- PopperJS -->
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.1/umd/popper.min.js"
+		        integrity="sha256-/ijcOLwFf26xEYAjW75FizKVo5tnTYiQddPZoLUHHZ8="
 		        crossorigin="anonymous"></script>
-		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
-		        integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
+		
+		<!-- Bootstrap -->
+		<link rel="stylesheet"
+		      href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
+		      integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh"
+		      crossorigin="anonymous">
+		<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
+		        integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6"
 		        crossorigin="anonymous"></script>
+		
+		<!-- Font Awesome -->
+		<link rel="stylesheet"
+		      href="/css/all.css">
+		
+		<script type="text/javascript">
+			$(document).ready(function () {
+				$('[data-toggle="tooltip"]').tooltip();
+			});
+		</script>
 	</th:block>
 </head>
 
@@ -51,54 +66,66 @@
 	</header>
 	
 	<main th:fragment="bodycontent">
-		<div class="container my-3">
+		<div class="container">
 			<!-- Header mit Titel und Aktionen -->
-			<div class="row d-flex justify-content-between align-items-center mb-3 border-bottom">
-				<h1 class="h1">Termine</h1>
+			<div class="row mt-2 border-bottom mb-3
+			            d-flex justify-content-between align-items-center">
+				<h1 class="h1 mb-2 text-break">
+					Termine</h1>
 				
-				<!-- Gruppenauswahl zur Begrenzung der angezeigten Termine -->
-				<div class="btn-toolbar" style="font-size: small">
-					<div class="dropdown">
+				<div class="btn-toolbar mb-2" style="font-size: small">
+					<!-- Gruppenauswahl zur Begrenzung der angezeigten Termine -->
+					<div th:class="${termine.gruppen.size() != 0 ? 'dropdown' : ''}">
+						<!-- deaktiviert, wenn keine Gruppen verfügbar -->
+						<span class="d-inline-block mx-2" tabindex="0"
+						      data-toggle="tooltip" title="Du gehörst keiner Gruppe an."
+						      th:if="${termine.gruppen.size() == 0}">
+							<button class="btn btn-outline-secondary dropdown-toggle"
+							        style="pointer-events: none"
+							        type="button" disabled>
+								Alle Gruppen
+							</button>
+						</span>
+						
+						<!-- aktiviert, wenn Gruppen verfügbar -->
 						<button class="btn btn-outline-secondary dropdown-toggle mx-2"
-						        data-toggle="dropdown" id="dropOperator" type="button">
+						        data-toggle="dropdown" id="dropOperator"
+						        type="button"
+						        th:if="*{termine.gruppen.size() != 0}">
 							<span th:text="${termine.selektierteGruppe.name}">
-								Gruppenname
-							</span>
+								Gruppenname</span>
 							
 							<i><span class="text-secondary"
 							         th:if="${termine.selektierteGruppe.id != '-1'}"
 							         th:text="'(ID: ' + ${termine.selektierteGruppe.id} + ')'">
-								Gruppen-ID
-							</span></i>
+								Gruppen-ID</span></i>
 						</button>
 						
 						<!-- Auswählbare Gruppen -->
-						<div class="dropdown-menu">
+						<div class="dropdown-menu" th:if="${termine.gruppen.size() != 0}">
 							<a class="dropdown-item" th:href="@{/termine2}">
-								Alle Gruppen
-							</a>
-							<div style="max-height:400px; max-width:300px; overflow:auto;">
+								Alle Gruppen</a>
+							
+							<div style="max-height: 400px; max-width: 300px; overflow: auto">
 								<div th:if="*{termine.gruppen.size() > 0}">
 									<div class="dropdown-divider"></div>
 								</div>
 								
-								<a class="dropdown-item" href="#" th:each="gruppe : ${termine.gruppen}"
+								<a class="dropdown-item" href="#"
+								   th:each="gruppe : ${termine.gruppen}"
 								   th:href="@{/termine2(gruppe=${gruppe.id})}">
 									<span th:text="${gruppe.name}">
-										Gruppenname
-									</span>
+										Gruppenname</span>
 									
 									<i><span class="text-secondary"
 									         th:text="'(ID: ' + ${gruppe.id} + ')'">
-										Gruppen-ID
-									</span></i>
-								</a>
-							</div>
+										Gruppen-ID</span></i></a></div>
 						</div>
 					</div>
 					
 					<a th:href="@{/termine2/termine-neu}">
-						<button class="btn btn-success">Neuer Termin</button>
+						<button class="btn btn-success">
+							<i class="fa fa-plus"></i> Neu</button>
 					</a>
 				</div>
 			</div>
@@ -107,75 +134,68 @@
 			<div class="alert alert-success alert-dissmissible fade show"
 			     th:if="${erfolg != null && erfolg != ''}">
 				<span th:text="${erfolg}">
-					Erfolgsmeldung
-				</span>
+					Erfolgsmeldung</span>
 				
-				<button class="close" data-dismiss="alert">×</button>
+				<button class="close" data-dismiss="alert">
+					×</button>
 			</div>
 			
 			<!-- Listen -->
 			<div class="row">
 				<!-- Linke Liste: Anstehende Termine -->
-				<div class="col-md-8 order-md-1">
-					<h2 class="h2">Anstehend</h2>
+				<div class="col-md-8 order-md-1 mb-3">
+					<h2 class="h2">
+						Anstehend</h2>
 					
-					<div class="text-secondary"
-					     style="font-size: small"
+					<div class="text-secondary mt-3"
 					     th:if="*{termine.getAbgeschlossen().size() == 0}">
-						<i>Es stehend keine Termine an.</i>
-					</div>
+						<i>Es stehen keine Termine an.</i></div>
 					
-					<div class="mt-3">
+					<div class="mt-3"
+					     th:if="*{termine.getAbgeschlossen().size() != 0}">
 						<!-- Termine aufsteigend nach dem Datum sortiert -->
 						<div class="mt-3 p-3 bg-light rounded"
 						     th:each="termin : ${termine.getAbgeschlossen()}">
 							<!-- Zusammenfassung -->
 							<div class="pb-2 border-bottom">
 								<div class="row d-flex justify-content-between align-items-center">
-
-  									<a data-toggle="tooltip" class="col" style="font-size: xx-large;"
-  										th:title="${termin.titel}"
-  										th:text="${#strings.abbreviate(termin.titel, 38)}">Title with hover
-  									</a>
-
-									<script>
-										$(document).ready(function(){
-  										$('[data-toggle="tooltip"]').tooltip();   
-										});
-									</script>
+									<h3 class="col-sm h3 mb-auto text-break">
+										<a data-toggle="tooltip" th:title="${termin.titel}"
+										   th:text="${#strings.abbreviate(termin.titel, 38)}">
+											Titel mit Tooltip</a></h3>
 									
-									<div class="col-sm-3" style="text-align: center; align:left; max-width:130px;"
+									<div class="col-sm-3 mb-auto text-success"
+									     style="text-align: right"
 									     th:text="'am ' + ${#temporals.format(termin.ergebnis,
 									              'dd.MM.yyyy HH:mm')} + ' Uhr'">
-										am DD.MM.YYYY, HH:MM
-									</div>
+										am DD.MM.YYYY, HH:MM</div>
 								</div>
 								
-								<div style="font-size: large" th:text=" ' Ort: ' + ${termin.ort}">
-									Ort
-								</div>
+								<div class="text-break" style="font-size: large"
+								     th:text="'Ort: ' + ${termin.ort}">
+									Ort</div>
 								
 								<!-- Gruppe, falls verfügbar -->
-								<div class="mt-1 text-secondary"
+								<div class="mt-1 text-secondary text-break"
 								     th:if="*{termin.gruppeId != null}">
-									für Gruppe
+									Gruppe:
 									
-									<i><span th:text="${termin.gruppeName}">Gruppe</span></i>
-								</div>
+									<i><span th:text="${termin.gruppeName}">
+										Gruppe</span></i></div>
 							</div>
 							
 							<!-- Beschreibung -->
-							<div class="mt-2 pb-2 border-bottom" style="font-size: small"
-							     th:if="${termin.beschreibung != null && termin.beschreibung != ''}"
-							     th:text="${#strings.abbreviate(termin.beschreibung,300)}">
-								Beschreibung
-							</div>
+							<div class="mt-2 pb-2 border-bottom text-break" style="font-size: small"
+							     th:if="${termin.beschreibung != null}
+							            and ${termin.beschreibung != ''}"
+							     th:text="${#strings.abbreviate(termin.beschreibung, 300)}">
+								Beschreibung</div>
 							
 							<!-- Weitere Aktionen -->
-							<div class="mt-3" style="text-align: center">
+							<div class="mt-2" style="text-align: center">
 								<a th:href="@{/termine2/{link}(link=${termin.link})}">
 									<button class="btn btn-outline-info" style="font-size: small"
-											type="submit" name="details" th:value="*{termin.link}">
+									        type="submit" name="details" th:value="*{termin.link}">
 										Details
 									</button>
 								</a>
@@ -184,92 +204,77 @@
 									Link:
 									
 									<span class="text-info" th:text="${termin.link}">
-										Link
-									</span>
-								</div>
+										Link</span></div>
 							</div>
 						</div>
 					</div>
 				</div>
 				
 				<!-- Rechte Liste: Offene Abstimmungen -->
-				<div class="col-md-4 order-md-2">
-					<h2 class="h2">Offen</h2>
+				<div class="col-md-4 order-md-2 mb-3">
+					<h2 class="h2">
+						Offen</h2>
 					
-					<div class="text-secondary"
-					     style="font-size: small"
+					<div class="text-secondary mb-3"
 					     th:if="*{termine.getOffen().size() == 0}">
-						<i>Es sind keine Termine offen.</i>
-					</div>
+						<i>Es sind keine Termine offen.</i></div>
 					
-					<div class="mt-3">
+					<div class="mt-3"
+					     th:if="*{termine.getOffen().size() != 0}">
 						<!-- Termine sollten aufsteigend nach ihrer Frist sortiert sein. -->
 						<div class="mt-3 p-3 bg-light rounded"
 						     th:each="termin : ${termine.getOffen()}">
 							<!-- Zusammenfassung -->
 							<div class="pb-2 border-bottom">
-
-								<a data-toggle="tooltip" style="font-size: x-large;"
-  										th:title="${termin.titel}"
-  										th:text="${#strings.abbreviate(termin.titel, 28)}">Title with hover
-  								</a>
-
-								<script>
-									$(document).ready(function(){
-  									$('[data-toggle="tooltip"]').tooltip();   
-									});
-								</script>
+								<h3 class="h3 mb-auto text-break">
+									<a data-toggle="tooltip" th:title="${termin.titel}"
+									   th:text="${#strings.abbreviate(termin.titel, 38)}">
+										Titel mit Tooltip</a></h3>
 								
-								<div th:text=" ' Ort: ' + ${termin.ort}">
-									Ort
-								</div>
+								<div th:text="'Ort: ' + ${termin.ort}">
+									Ort</div>
 								
 								<!-- Gruppe, falls verfügbar -->
-								<div class="mt-1 text-secondary"
+								<div class="mt-1 text-secondary text-break"
 								     th:if="*{termin.gruppeId != null}">
-									für Gruppe
+									Gruppe:
 									
-									<i><span th:text="${termin.gruppeName}">Gruppe</span></i>
-								</div>
+									<i><span th:text="${termin.gruppeName}">
+										Gruppe</span></i></div>
 							</div>
 							
 							<!-- Beschreibung -->
-							<div class="mt-2 pb-2 border-bottom" style="font-size: small"
-							     th:if="*{termin.beschreibung != null && termin.beschreibung != ''}"
-							     th:text="${#strings.abbreviate(termin.beschreibung,135)}">
-								Beschreibung
-							</div>
+							<div class="mt-2 pb-2 border-bottom text-break" style="font-size: small"
+							     th:if="*{termin.beschreibung != null}
+							            and *{termin.beschreibung != ''}"
+							     th:text="${#strings.abbreviate(termin.beschreibung, 135)}">
+								Beschreibung</div>
 							
 							<!-- Weitere Aktionen -->
-							<div class="mt-2">
-								<div class="text-secondary"
-								     style="font-size: small; text-align: center"
-								     th:text="'offen bis ' + ${#temporals.format(termin.frist,
+							<div class="mt-2" style="text-align: center">
+								<div class="text-secondary" style="font-size: small"
+								     th:text="'offen bis: ' + ${#temporals.format(termin.frist,
 								              'dd.MM.yyyy, HH:mm')}">
-									offen bis DD.MM.YYYY, HH:MM
+									offen bis: DD.MM.YYYY, HH:MM
 								</div>
 								
-								<div class="mt-2" style="text-align: center">
-									<a th:href="@{/termine2/{link}(link=${termin.link})}">
-										<button class="btn" style="font-size: small" type="submit"
-										        name="details"
-										        th:value="*{termin.link}"
-										        th:classappend="${termin.teilgenommen}
-										                        ? 'btn-outline-info'
-										                        : 'btn-primary'"
-										        th:text="${termin.teilgenommen}
-										                 ? 'Details' : 'Abstimmen'">
-										</button>
-									</a>
+								<a th:href="@{/termine2/{link}(link=${termin.link})}">
+									<button class="btn mt-2" style="font-size: small"
+									        name="details" th:value="*{termin.link}"
+									        th:classappend="${termin.teilgenommen}
+									                        ? 'btn-outline-info'
+									                        : 'btn-primary'"
+									        th:text="${termin.teilgenommen}
+									                 ? 'Details' : 'Abstimmen'">
+										Details oder Abstimmen
+									</button>
+								</a>
+								
+								<div class="mt-2 text-secondary" style="font-size: small">
+									Link:
 									
-									<div class="mt-2 text-secondary" style="font-size: small">
-										Link:
-										
-										<span class="text-info" th:text="${termin.link}">
-											Link
-										</span>
-									</div>
-								</div>
+									<span class="text-info" th:text="${termin.link}">
+										Link</span></div>
 							</div>
 						</div>
 					</div>

--- a/src/main/resources/templates/termine.html
+++ b/src/main/resources/templates/termine.html
@@ -97,12 +97,14 @@
 							
 							<i><span class="text-secondary"
 							         th:if="${termine.selektierteGruppe.id != '-1'}"
-							         th:text="'(ID: ' + ${termine.selektierteGruppe.id} + ')'">
+							         th:text="'(ID: ' + ${#strings.abbreviate(
+							                              termine.selektierteGruppe.id, 11)} + ')'">
 								Gruppen-ID</span></i>
 						</button>
 						
 						<!-- Auswählbare Gruppen -->
-						<div class="dropdown-menu" th:if="${termine.gruppen.size() != 0}">
+						<div class="dropdown-menu dropdown-menu-right"
+						     th:if="${termine.gruppen.size() != 0}">
 							<a class="dropdown-item" th:href="@{/termine2}">
 								Alle Gruppen</a>
 							

--- a/src/main/resources/templates/umfragen-neu.html
+++ b/src/main/resources/templates/umfragen-neu.html
@@ -126,7 +126,7 @@
 								<optgroup label="Gruppen">
 									<option th:each="gruppe, iter : ${gruppen}"
 									        th:value="${gruppen[__${iter.index}__].id}"
-									        th:text="${gruppe.name}">
+									        th:text="${gruppe.name} + ' (' + ${gruppe.id} + ')'">
 										Gruppe
 									</option>
 								</optgroup>

--- a/src/main/resources/templates/umfragen-neu.html
+++ b/src/main/resources/templates/umfragen-neu.html
@@ -126,7 +126,7 @@
 								<optgroup label="Gruppen">
 									<option th:each="gruppe, iter : ${gruppen}"
 									        th:value="${gruppen[__${iter.index}__].id}"
-									        th:text="${gruppe.name} + ' (' + ${gruppe.id} + ')'">
+									        th:text="${gruppe.name} + ' (ID: ' + ${gruppe.id} + ')'">
 										Gruppe
 									</option>
 								</optgroup>

--- a/src/main/resources/templates/umfragen.html
+++ b/src/main/resources/templates/umfragen.html
@@ -166,11 +166,16 @@
 										   th:text="${#strings.abbreviate(umfrage.titel, 38)}">
 											Titel mit Tooltip</a></h3>
 									
-									<div class="col-sm-3 mb-auto text-secondary"
-									     style="text-align: right"
-									     th:text="'vom ' + ${#temporals.format(umfrage.frist,
-									              'dd.MM.yyyy HH:mm')} + ' Uhr'">
-										vom DD.MM.YYYY, HH:MM</div>
+									<div class="col-sm-4 mb-auto text-secondary"
+									     style="text-align: right">
+										<div th:text="'vom ' + ${#temporals.format(umfrage.frist,
+										              'dd.MM.yyyy')}">
+											vom dd.MM.yyyy</div>
+										
+										<div th:text="'um ' + ${#temporals.format(umfrage.frist,
+										              'HH:mm')} + ' Uhr'">
+											um HH:mm</div>
+									</div>
 								</div>
 								
 								<div style="font-size: large"

--- a/src/main/resources/templates/umfragen.html
+++ b/src/main/resources/templates/umfragen.html
@@ -97,12 +97,14 @@
 							
 							<i><span class="text-secondary"
 							         th:if="${umfragen.selektierteGruppe.id != '-1'}"
-							         th:text="'(ID: ' + ${umfragen.selektierteGruppe.id} + ')'">
+							         th:text="'(ID: ' + ${#strings.abbreviate(
+							                             umfragen.selektierteGruppe.id, 11)} + ')'">
 								Gruppen-ID</span></i>
 						</button>
 						
 						<!-- Auswählbare Gruppen -->
-						<div class="dropdown-menu" th:if="${umfragen.gruppen.size() != 0}">
+						<div class="dropdown-menu dropdown-menu-right"
+						     th:if="${umfragen.gruppen.size() != 0}">
 							<a class="dropdown-item" th:href="@{/termine2/umfragen}">
 								Alle Gruppen</a>
 							

--- a/src/main/resources/templates/umfragen.html
+++ b/src/main/resources/templates/umfragen.html
@@ -9,20 +9,35 @@
 	<title>Umfragen</title>
 	<th:block th:fragment="headcontent">
 		<!-- Links, Scripts, Styles -->
-		<link rel="stylesheet"
-		      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
-		      integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
-		      crossorigin="anonymous">
 		
-		<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
-		        integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+		<!-- jQuery -->
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"
+		        integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
 		        crossorigin="anonymous"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"
-		        integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q"
+		
+		<!-- PopperJS -->
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.1/umd/popper.min.js"
+		        integrity="sha256-/ijcOLwFf26xEYAjW75FizKVo5tnTYiQddPZoLUHHZ8="
 		        crossorigin="anonymous"></script>
-		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
-		        integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
+		
+		<!-- Bootstrap -->
+		<link rel="stylesheet"
+		      href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
+		      integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh"
+		      crossorigin="anonymous">
+		<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
+		        integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6"
 		        crossorigin="anonymous"></script>
+		
+		<!-- Font Awesome -->
+		<link rel="stylesheet"
+		      href="/css/all.css">
+		
+		<script type="text/javascript">
+			$(document).ready(function () {
+				$('[data-toggle="tooltip"]').tooltip();
+			});
+		</script>
 	</th:block>
 </head>
 
@@ -51,52 +66,66 @@
 	</header>
 	
 	<main th:fragment="bodycontent">
-		<div class="container my-3">
+		<div class="container">
 			<!-- Header mit Titel und Aktionen -->
-			<div class="row d-flex justify-content-between align-items-center mb-3 border-bottom">
-				<h1 class="h1">Umfragen</h1>
+			<div class="row mt-2 border-bottom mb-3
+			            d-flex justify-content-between align-items-center">
+				<h1 class="h1 mb-2 text-break">
+					Umfragen</h1>
 				
-				<!-- Gruppenauswahl zur Begrenzung der angezeigten Termine -->
-				<div class="btn-toolbar" style="font-size: small">
-					<div class="dropdown">
+				<div class="btn-toolbar mb-2" style="font-size: small">
+					<!-- Gruppenauswahl zur Begrenzung der angezeigten Termine -->
+					<div th:class="${umfragen.gruppen.size() != 0 ? 'dropdown' : ''}">
+						<!-- deaktiviert, wenn keine Gruppen verfügbar -->
+						<span class="d-inline-block mx-2" tabindex="0"
+						      data-toggle="tooltip" title="Du gehörst keiner Gruppe an."
+						      th:if="${umfragen.gruppen.size() == 0}">
+							<button class="btn btn-outline-secondary dropdown-toggle"
+							        style="pointer-events: none"
+							        type="button" disabled>
+								Alle Gruppen
+							</button>
+						</span>
+						
+						<!-- aktiviert, wenn Gruppen verfügbar -->
 						<button class="btn btn-outline-secondary dropdown-toggle mx-2"
-						        data-toggle="dropdown" id="dropOperator" type="button">
+						        data-toggle="dropdown" id="dropOperator"
+						        type="button"
+						        th:if="${umfragen.gruppen.size() != 0}">
 							<span th:text="${umfragen.selektierteGruppe.name}">
-								Gruppenname
-							</span>
+								Gruppenname</span>
 							
 							<i><span class="text-secondary"
 							         th:if="${umfragen.selektierteGruppe.id != '-1'}"
 							         th:text="'(ID: ' + ${umfragen.selektierteGruppe.id} + ')'">
-								Gruppen-ID
-							</span></i>
+								Gruppen-ID</span></i>
 						</button>
 						
 						<!-- Auswählbare Gruppen -->
-						<div class="dropdown-menu">
+						<div class="dropdown-menu" th:if="${umfragen.gruppen.size() != 0}">
 							<a class="dropdown-item" th:href="@{/termine2/umfragen}">
-								Alle Gruppen
-							</a>
-							<div style="max-height:400px; max-width:300px; overflow:auto;">
+								Alle Gruppen</a>
+							
+							<div style="max-height: 400px; max-width: 300px; overflow: auto">
 								<div th:if="*{umfragen.gruppen.size() > 0}">
 									<div class="dropdown-divider"></div>
 								</div>
-								<a class="dropdown-item" href="#" th:each="gruppe : ${umfragen.gruppen}"
+								
+								<a class="dropdown-item" href="#"
+								   th:each="gruppe : ${umfragen.gruppen}"
 								   th:href="@{/termine2/umfragen(gruppe=${gruppe.id})}">
 									<span th:text="${gruppe.name}">
-										Gruppenname
-									</span>
+										Gruppenname</span>
 									
 									<i><span class="text-secondary"
 									         th:text="'(ID: ' + ${gruppe.id} + ')'">
-										Gruppen-ID
-									</span></i>
-								</a>
-							</div>
+										Gruppen-ID</span></i></a></div>
 						</div>
 					</div>
+					
 					<a th:href="@{/termine2/umfragen-neu}">
-						<button class="btn btn-success">Neue Umfrage</button>
+						<button class="btn btn-success">
+							<i class="fa fa-plus"></i> Neu</button>
 					</a>
 				</div>
 			</div>
@@ -105,168 +134,148 @@
 			<div class="alert alert-success alert-dissmissible fade show"
 			     th:if="${erfolg != null && erfolg != ''}">
 				<span th:text="${erfolg}">
-					Erfolgsmeldung
-				</span>
+					Erfolgsmeldung</span>
 				
-				<button class="close" data-dismiss="alert">×</button>
+				<button class="close" data-dismiss="alert">
+					×</button>
 			</div>
 			
 			<!-- Listen -->
 			<div class="row">
 				<!-- Linke Liste: Umfrageergebnisse -->
-				<div class="col-md-8 order-md-1">
-					<h2 class="h2">Ergebnisse</h2>
+				<div class="col-md-8 order-md-1 mb-3">
+					<h2 class="h2">
+						Ergebnisse</h2>
 					
-					<div class="text-secondary"
-					     style="font-size: small"
+					<div class="text-secondary mt-3"
 					     th:if="*{umfragen.getAbgeschlossen().size() == 0}">
-						<i>Es liegen keine Ergebnisse vor.</i>
-					</div>
+						<i>Es liegen keine Ergebnisse vor.</i></div>
 					
-					<div class="mt-3">
+					<div class="mt-3"
+					     th:if="*{umfragen.getAbgeschlossen().size() != 0}">
 						<!-- Abstimmungen aufsteigend nach dem Enddatum sortiert -->
 						<div class="mt-3 p-3 bg-light rounded"
 						     th:each="umfrage : ${umfragen.getAbgeschlossen()}">
 							<!-- Zusammenfassung -->
 							<div class="pb-2 border-bottom">
 								<div class="row d-flex justify-content-between align-items-center">
-
-									<a data-toggle="tooltip" class="col" style="font-size: xx-large;"
-  										th:title="${umfrage.titel}"
-  										th:text="${#strings.abbreviate(umfrage.titel, 38)}">Title with hover
-  									</a>
-  									
-  									<script>
-										$(document).ready(function(){
-  										$('[data-toggle="tooltip"]').tooltip();   
-										});
-									</script>
+									<h3 class="col-sm h3 mb-auto text-break">
+										<a data-toggle="tooltip" th:title="${umfrage.titel}"
+										   th:text="${#strings.abbreviate(umfrage.titel, 38)}">
+											Titel mit Tooltip</a></h3>
 									
-									<div class="col-sm-3" style="text-align: center; align:left; max-width:130px;"
+									<div class="col-sm-3 mb-auto text-secondary"
+									     style="text-align: right"
 									     th:text="'vom ' + ${#temporals.format(umfrage.frist,
 									              'dd.MM.yyyy HH:mm')} + ' Uhr'">
-										vom DD.MM.YYYY, HH:MM
-									</div>
+										vom DD.MM.YYYY, HH:MM</div>
 								</div>
 								
-								<div class="text-success" style="font-size: x-large"
-								     th:text="${#strings.abbreviate(umfrage.umfragenErgebnis,300)}">
-									Ergebnis
-								</div>
+								<div style="font-size: large"
+								     th:classappend="${umfrage.ergebnis != null
+								                     ? 'text-success' : 'text-warning'}"
+								     th:text="${umfrage.ergebnis == null
+								              ? 'Niemand hat an dieser Umfrage teilgenommen.'
+								              : #strings.abbreviate(umfrage.ergebnis, 300)}">
+									Ergebnis</div>
 								
 								<!-- Gruppe, falls verfügbar -->
-								<div class="mt-1 text-secondary"
+								<div class="mt-1 text-secondary text-break"
 								     th:if="*{umfrage.gruppeId != null}">
-									für Gruppe
+									Gruppe:
 									
-									<i><span th:text="${umfrage.gruppeName}">Gruppe</span></i>
-								</div>
+									<i><span th:text="${umfrage.gruppeName}">
+										Gruppe</span></i></div>
 							</div>
 							
 							<!-- Beschreibung -->
-							<div class="mt-2 pb-2 border-bottom" style="font-size: small"
-							     th:if="${umfrage.beschreibung != null &&
-							            umfrage.beschreibung != ''}"
-							     th:text="${#strings.abbreviate(umfrage.beschreibung,300)}">
-								Beschreibung
-							</div>
+							<div class="mt-2 pb-2 border-bottom text-break" style="font-size: small"
+							     th:if="${umfrage.beschreibung != null}
+							            and ${umfrage.beschreibung != ''}"
+							     th:text="${#strings.abbreviate(umfrage.beschreibung, 300)}">
+								Beschreibung</div>
 							
 							<!-- Weitere Aktionen -->
-							<div class="mt-3" style="text-align: center">
-								<form th:action="@{/termine2/umfragen}" method="post">
+							<div class="mt-2" style="text-align: center">
+								<a th:href="@{/termine2/umfragen/{link}(link=${umfrage.link})}">
 									<button class="btn btn-outline-info" style="font-size: small"
 									        type="submit" name="details" th:value="*{umfrage.link}">
 										Details
 									</button>
-								</form>
+								</a>
 								
 								<div class="mt-2 text-secondary" style="font-size: small">
 									Link:
 									
 									<span class="text-info" th:text="${umfrage.link}">
-										Link
-									</span>
-								</div>
+										Link</span></div>
 							</div>
 						</div>
 					</div>
 				</div>
 				
 				<!-- Rechte Liste: Offene Umfragen -->
-				<div class="col-md-4 order-md-2">
-					<h2 class="h2">Offen</h2>
+				<div class="col-md-4 order-md-2 mb-3">
+					<h2 class="h2">
+						Offen</h2>
 					
-					<div class="text-secondary"
-					     style="font-size: small"
+					<div class="text-secondary mt-3"
 					     th:if="*{umfragen.getOffen().size() == 0}">
-						<i>Es sind keine Abstimmungen offen.</i>
-					</div>
+						<i>Es sind keine Abstimmungen offen.</i></div>
 					
-					<div class="mt-3">
+					<div class="mt-3"
+					     th:if="*{umfragen.getOffen().size() != 0}">
 						<!-- Umfragen sollten aufsteigend nach ihrer Frist sortiert sein. -->
 						<div class="mt-3 p-3 bg-light rounded"
-						     th:each="offeneUmfrage : ${umfragen.getOffen()}">
+						     th:each="umfrage : ${umfragen.getOffen()}">
 							<!-- Zusammenfassung -->
 							<div class="pb-2 border-bottom">
-								
-								<a data-toggle="tooltip" style="font-size: x-large;"
-  										th:title="${offeneUmfrage.titel}"
-  										th:text="${#strings.abbreviate(offeneUmfrage.titel, 28)}">Title with hover
-  								</a>
-
-								<script>
-									$(document).ready(function(){
-  									$('[data-toggle="tooltip"]').tooltip();   
-									});
-								</script>
+								<h3 class="h3 mb-auto text-break">
+									<a data-toggle="tooltip" th:title="${umfrage.titel}"
+									   th:text="${#strings.abbreviate(umfrage.titel, 38)}">
+										Titel mit Tooltip</a></h3>
 								
 								<!-- Gruppe, falls verfügbar -->
-								<div class="mt-1 text-secondary"
-								     th:if="*{offeneUmfrage.gruppeId != null}">
-									für Gruppe
+								<div class="mt-1 text-secondary text-break"
+								     th:if="*{umfrage.gruppeId != null}">
+									Gruppe:
 									
-									<i><span th:text="${offeneUmfrage.gruppeName}">Gruppe</span></i>
-								</div>
+									<i><span th:text="${umfrage.gruppeName}">
+										Gruppe</span></i></div>
 							</div>
 							
 							<!-- Beschreibung -->
-							<div class="mt-2 pb-2 border-bottom" style="font-size: small"
-							     th:if="*{offeneUmfrage.beschreibung != null &&
-							            offeneUmfrage.beschreibung != ''}"
-							     th:text="${#strings.abbreviate(offeneUmfrage.beschreibung,135)}">
-								Beschreibung
-							</div>
+							<div class="mt-2 pb-2 border-bottom text-break" style="font-size: small"
+							     th:if="*{umfrage.beschreibung != null}
+							            and *{umfrage.beschreibung != ''}"
+							     th:text="${#strings.abbreviate(umfrage.beschreibung, 135)}">
+								Beschreibung</div>
 							
 							<!-- Weitere Aktionen -->
-							<div class="mt-2">
-								<div class="text-secondary"
-								     style="font-size: small; text-align: center"
-								     th:text="'offen bis ' + ${#temporals.format(offeneUmfrage.frist,
+							<div class="mt-2" style="text-align: center">
+								<div class="text-secondary" style="font-size: small"
+								     th:text="'offen bis: ' + ${#temporals.format(umfrage.frist,
 								              'dd.MM.yyyy, HH:mm')}">
-									offen bis DD.MM.YYYY, HH:MM
+									offen bis: DD.MM.YYYY, HH:MM
 								</div>
 								
-								<div class="mt-2" style="text-align: center">
-									<form th:action="@{/termine2/umfragen}" method="post">
-										<button class="btn" style="font-size: small" type="submit"
-										        name="details"
-										        th:value="*{offeneUmfrage.link}"
-										        th:classappend="${offeneUmfrage.teilgenommen}
-										                        ? 'btn-outline-info'
-										                        : 'btn-primary'"
-										        th:text="${offeneUmfrage.teilgenommen}
-										                 ? 'Details' : 'Abstimmen'">
-										</button>
-									</form>
+								<a th:href="@{/termine2/umfragen/{link}(link=${umfrage.link})}">
+									<button class="btn mt-2" style="font-size: small"
+									        name="details" th:value="*{umfrage.link}"
+									        th:classappend="${umfrage.teilgenommen}
+									                        ? 'btn-outline-info'
+									                        : 'btn-primary'"
+									        th:text="${umfrage.teilgenommen}
+									                 ? 'Details' : 'Abstimmen'">
+										Details oder Abstimmen
+									</button>
+								</a>
+								
+								<div class="mt-2 text-secondary" style="font-size: small">
+									Link:
 									
-									<div class="mt-2 text-secondary" style="font-size: small">
-										Link:
-										
-										<span class="text-info" th:text="${offeneUmfrage.link}">
-											Link
-										</span>
-									</div>
-								</div>
+									<span class="text-info" th:text="${umfrage.link}">
+										Link</span></div>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
* Umfrage Model
  - Removed unnecessary 'umfragenErgebnis': There is already 'ergebnis'.

* Liste UIs
  * Scripts:
    * Updated scripts: jQuery, PopperJS, Bootstrap
    + Added Font Awesome stylesheet
    * Moved tooltip script out of body
  * Fixed whitespace and linebreaks
  * Tweaked paddings and margins
  * Titel: If the buttons do not fit on the same row as the title, then there will now be some vertical space.
  * Gruppenfilter: If the user is not a member of any Gruppe, then the dropdown menu will be disabled and a tooltip be shown instead.
  * Neuer Termin: Added icon and shortened caption
  * Listen: Added text breaks: The Title, Ort and Beschreibung will now fit inside their container.
  * Miscellaneous changes

  * Terminliste UIs:
    * Ergebnis: Styled text: The Ergebnis will now be shown in green and be aligned to the top right corner of the container.

  * Umfrageliste UI
    + Ergebnis: Added alternate text if no-one participated in the Abstimmung
    * Details: Replaced post button with link